### PR TITLE
Agrega ventas objetivo y corrige enlace en resultados

### DIFF
--- a/SimulacionCmiWPF/MainViewModel.cs
+++ b/SimulacionCmiWPF/MainViewModel.cs
@@ -16,6 +16,7 @@ public class MainViewModel : INotifyPropertyChanged
     private int _hastaVisita = 100;
     private double _probRecuerda = 0.35;
     private double _probCompraDudoso = 0.60;
+    private int _ventasObjetivo = 10000;
 
     public int Visitas
     {
@@ -47,6 +48,12 @@ public class MainViewModel : INotifyPropertyChanged
         set { _probCompraDudoso = value; OnPropertyChanged(nameof(ProbabilidadDudosoCompra)); }
     }
 
+    public int VentasObjetivo
+    {
+        get => _ventasObjetivo;
+        set { _ventasObjetivo = value; OnPropertyChanged(nameof(VentasObjetivo)); }
+    }
+
     public ObservableCollection<ProbabilidadesFila> TablaRecuerda { get; } = new([
         new ProbabilidadesFila { No = 0.55, Dudoso = 0.15, Si = 0.30 }
     ]);
@@ -71,7 +78,7 @@ public class MainViewModel : INotifyPropertyChanged
             var motor = new MotorCmi(ProbabilidadRecuerda,
                 [TablaRecuerda[0].No, TablaRecuerda[0].Dudoso, TablaRecuerda[0].Si],
                 [TablaNoRecuerda[0].No, TablaNoRecuerda[0].Dudoso, TablaNoRecuerda[0].Si],
-                ProbabilidadDudosoCompra, 10000);
+                ProbabilidadDudosoCompra, VentasObjetivo);
             var res = motor.Simular(Visitas, DesdeVisita, HastaVisita);
             var vm = new ResultadosViewModel(res, motor.CalcularVisitasAnaliticas());
             var win = new VentanaResultados { DataContext = vm };

--- a/SimulacionCmiWPF/MainWindow.xaml
+++ b/SimulacionCmiWPF/MainWindow.xaml
@@ -1,50 +1,76 @@
 <Window x:Class="SimulacionCmiWPF.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         Title="Simulación CMI" Height="600" Width="900">
   <Grid Margin="10">
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
       <RowDefinition Height="*"/>
     </Grid.RowDefinitions>
 
-    <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+    <Grid Margin="0,0,0,10">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="80"/>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="60"/>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="60"/>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="60"/>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="60"/>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="100"/>
+        <ColumnDefinition Width="*"/>
+      </Grid.ColumnDefinitions>
+
       <TextBlock Text="Visitas:" VerticalAlignment="Center"/>
-      <TextBox Width="80" Margin="5,0" Text="{Binding Visitas}"/>
-      <TextBlock Text="Desde:" VerticalAlignment="Center" Margin="10,0,0,0"/>
-      <TextBox Width="60" Margin="5,0" Text="{Binding DesdeVisita}"/>
-      <TextBlock Text="Hasta:" VerticalAlignment="Center" Margin="10,0,0,0"/>
-      <TextBox Width="60" Margin="5,0" Text="{Binding HastaVisita}"/>
-      <TextBlock Text="P(Recuerda):" VerticalAlignment="Center" Margin="10,0,0,0"/>
-      <TextBox Width="60" Margin="5,0" Text="{Binding ProbabilidadRecuerda}"/>
-      <TextBlock Text="P(Compra|Dudoso):" VerticalAlignment="Center" Margin="10,0,0,0"/>
-      <TextBox Width="60" Margin="5,0" Text="{Binding ProbabilidadDudosoCompra}"/>
-      <Button Content="Ejecutar simulación" Margin="10,0" Command="{Binding EjecutarSimulacion}"/>
-      <Button Content="Ver enunciado" Margin="10,0" Command="{Binding MostrarEnunciado}"/>
-    </StackPanel>
+      <TextBox Grid.Column="1" Width="80" Margin="5,0" Text="{Binding Visitas}"/>
+      <TextBlock Grid.Column="2" Text="Desde:" VerticalAlignment="Center" Margin="10,0,0,0"/>
+      <TextBox Grid.Column="3" Width="60" Margin="5,0" Text="{Binding DesdeVisita}"/>
+      <TextBlock Grid.Column="4" Text="Hasta:" VerticalAlignment="Center" Margin="10,0,0,0"/>
+      <TextBox Grid.Column="5" Width="60" Margin="5,0" Text="{Binding HastaVisita}"/>
+      <TextBlock Grid.Column="6" Text="P(Recuerda):" VerticalAlignment="Center" Margin="10,0,0,0"/>
+      <TextBox Grid.Column="7" Width="60" Margin="5,0" Text="{Binding ProbabilidadRecuerda}"/>
+      <TextBlock Grid.Column="8" Text="P(Compra|Dudoso):" VerticalAlignment="Center" Margin="10,0,0,0"/>
+      <TextBox Grid.Column="9" Width="60" Margin="5,0" Text="{Binding ProbabilidadDudosoCompra}"/>
+      <TextBlock Grid.Column="10" Text="Ventas objetivo:" VerticalAlignment="Center" Margin="10,0,0,0"/>
+      <xctk:IntegerUpDown Grid.Column="11" Width="100" Margin="5,0" Value="{Binding VentasObjetivo}" Minimum="0"/>
+      <StackPanel Grid.Column="12" Orientation="Horizontal" HorizontalAlignment="Right" Margin="10,0,0,0">
+        <Button Content="Ejecutar simulación" Margin="5,0" Command="{Binding EjecutarSimulacion}"/>
+        <Button Content="Ver enunciado" Margin="5,0" Command="{Binding MostrarEnunciado}"/>
+      </StackPanel>
+    </Grid>
 
     <Grid Grid.Row="1">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="*"/>
       </Grid.ColumnDefinitions>
-      <DataGrid Grid.Column="0" ItemsSource="{Binding TablaRecuerda}" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False">
-        <DataGrid.Columns>
-          <DataGridTextColumn Header="No" Binding="{Binding No, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-          <DataGridTextColumn Header="Dudoso" Binding="{Binding Dudoso, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-          <DataGridTextColumn Header="Sí" Binding="{Binding Si, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-        </DataGrid.Columns>
-      </DataGrid>
-      <DataGrid Grid.Column="1" ItemsSource="{Binding TablaNoRecuerda}" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False">
-        <DataGrid.Columns>
-          <DataGridTextColumn Header="No" Binding="{Binding No, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-          <DataGridTextColumn Header="Dudoso" Binding="{Binding Dudoso, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-          <DataGridTextColumn Header="Sí" Binding="{Binding Si, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-        </DataGrid.Columns>
-      </DataGrid>
-    </Grid>
 
-    <TextBlock Grid.Row="2" Text=""/>
+      <StackPanel Grid.Column="0" Margin="0,0,5,0">
+        <TextBlock Text="Probabilidades si RECUERDA" FontWeight="Bold" Margin="0,0,0,5"/>
+        <DataGrid ItemsSource="{Binding TablaRecuerda}" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="No" Binding="{Binding No, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+            <DataGridTextColumn Header="Dudoso" Binding="{Binding Dudoso, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+            <DataGridTextColumn Header="Sí" Binding="{Binding Si, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+          </DataGrid.Columns>
+        </DataGrid>
+      </StackPanel>
+
+      <StackPanel Grid.Column="1" Margin="5,0,0,0">
+        <TextBlock Text="Probabilidades si NO RECUERDA" FontWeight="Bold" Margin="0,0,0,5"/>
+        <DataGrid ItemsSource="{Binding TablaNoRecuerda}" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="No" Binding="{Binding No, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+            <DataGridTextColumn Header="Dudoso" Binding="{Binding Dudoso, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+            <DataGridTextColumn Header="Sí" Binding="{Binding Si, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+          </DataGrid.Columns>
+        </DataGrid>
+      </StackPanel>
+    </Grid>
   </Grid>
 </Window>

--- a/SimulacionCmiWPF/SimulacionCmiWPF.csproj
+++ b/SimulacionCmiWPF/SimulacionCmiWPF.csproj
@@ -13,8 +13,9 @@
       <ProjectReference Include="..\SimulacionCmiCore\SimulacionCmiCore.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <PackageReference Include="ScottPlot.WPF" Version="5.0.55" />
+      <PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.0" />
     </ItemGroup>
 
 </Project>

--- a/SimulacionCmiWPF/VentanaResultados.xaml
+++ b/SimulacionCmiWPF/VentanaResultados.xaml
@@ -10,7 +10,7 @@
     </Grid.RowDefinitions>
     <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0,0,0,10">
       <Run Text="Visitas necesarias (simulación): "/>
-      <Run Text="{Binding VisitaObjetivo}"/>
+      <Run Text="{Binding VisitaObjetivo, Mode=OneWay}"/>
       <Run Text="  |  Visitas necesarias (analítico): "/>
       <Run Text="{Binding VisitasAnaliticas, StringFormat=F0}"/>
       <Run Text="  |  P(Def. Sí): "/>


### PR DESCRIPTION
## Resumen
- Corrige el enlace de `VisitaObjetivo` para evitar excepciones de TwoWay.
- Añade propiedad y control de `VentasObjetivo` junto con reordenamiento visual de la ventana principal.
- Incluye `Extended.Wpf.Toolkit` para usar un control numérico.

## Testing
- `dotnet build SimulacionCmiCore/SimulacionCmiCore.csproj`
- `dotnet test SimulacionCmiCore.Tests/SimulacionCmiCore.Tests.csproj`
- `dotnet build SimulacionCmiWPF/SimulacionCmiWPF.csproj` *(falla: falta Microsoft.NET.Sdk.WindowsDesktop en Linux)*

------
https://chatgpt.com/codex/tasks/task_e_688ff0ca2c84833289f72fc68b653f43