### PR TITLE
Agregar semilla RNG y validaciones en la simulación

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ Este proyecto contiene una simulación del problema de la empresa **CMI Corporat
 La aplicación WPF permite configurar las probabilidades, ejecutar la simulación y
 visualizar tablas y gráficos con los resultados.
 
+## Parámetros de entrada
+
+En la ventana principal se deben ingresar los siguientes valores:
+
+| Parámetro | Rango válido |
+| --- | --- |
+| Visitas a simular | 10 &le; valor &le; 2 147 483 647 |
+| Desde visita | 1 &le; valor &le; Hasta visita |
+| Hasta visita | valor &le; Visitas a simular y (Hasta − Desde) &le; 10 000 |
+| Semilla RNG | vacío para aleatoria, o cualquier entero de 32 bits |
+| P(Recuerda) | 0 < valor < 1 |
+| P(Compra | Dudoso) | 0 < valor < 1 |
+| Ventas objetivo | 0 < valor < 2 147 483 647 |
+| Tabla "Recuerda" | tres columnas, cada celda 0 < x < 1, suma de la fila = 1 |
+| Tabla "No recuerda" | mismas reglas que la tabla "Recuerda" |
+
 ## Enunciado
 
 CMI Corporation llevó a cabo una prueba para evaluar la efectividad de un nuevo anuncio por televisión para uno de sus productos domésticos. El anuncio se mostró en un mercado de prueba durante dos semanas. En el estudio de seguimiento se contactó telefónicamente con una selección aleatoria de personas y se les hizo una serie de preguntas sobre la posible compra del producto.

--- a/SimulacionCmiWPF/MainViewModel.cs
+++ b/SimulacionCmiWPF/MainViewModel.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows;
@@ -17,11 +19,13 @@ public class MainViewModel : INotifyPropertyChanged
     private double _probRecuerda = 0.35;
     private double _probCompraDudoso = 0.60;
     private int _ventasObjetivo = 10000;
+    private int? _semillaRng;
 
-    public int Visitas
+    /// <summary>Total de visitas a simular.</summary>
+    public int VisitasASimular
     {
         get => _visitas;
-        set { _visitas = value; OnPropertyChanged(nameof(Visitas)); }
+        set { _visitas = value; OnPropertyChanged(nameof(VisitasASimular)); }
     }
 
     public int DesdeVisita
@@ -55,6 +59,13 @@ public class MainViewModel : INotifyPropertyChanged
         set { _ventasObjetivo = value; OnPropertyChanged(nameof(VentasObjetivo)); }
     }
 
+    /// <summary>Semilla opcional del generador aleatorio.</summary>
+    public int? SemillaRng
+    {
+        get => _semillaRng;
+        set { _semillaRng = value; OnPropertyChanged(nameof(SemillaRng)); }
+    }
+
     public ObservableCollection<ProbabilidadesFila> TablaRecuerda { get; } = new([
         new ProbabilidadesFila { No = 0.55, Dudoso = 0.15, Si = 0.30 }
     ]);
@@ -68,19 +79,24 @@ public class MainViewModel : INotifyPropertyChanged
 
     public MainViewModel()
     {
-        EjecutarSimulacion = new RelayCommand(_ => Simular());
+        EjecutarSimulacion = new RelayCommand(_ => Simular(), _ => Validar(out _));
         MostrarEnunciado = new RelayCommand(_ => MostrarReadme());
     }
 
     private void Simular()
     {
+        if (!Validar(out string mensaje))
+        {
+            MessageBox.Show(mensaje, "Validación", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
         try
         {
             var motor = new MotorCmi(ProbabilidadRecuerda,
                 [TablaRecuerda[0].No, TablaRecuerda[0].Dudoso, TablaRecuerda[0].Si],
                 [TablaNoRecuerda[0].No, TablaNoRecuerda[0].Dudoso, TablaNoRecuerda[0].Si],
                 ProbabilidadDudosoCompra, VentasObjetivo);
-            var res = motor.Simular(Visitas, DesdeVisita, HastaVisita);
+            var res = motor.Simular(VisitasASimular, DesdeVisita, HastaVisita, SemillaRng);
             var vm = new ResultadosViewModel(res, motor.CalcularVisitasAnaliticas());
             var win = new VentanaResultados { DataContext = vm };
             win.Owner = Application.Current.MainWindow;
@@ -99,6 +115,50 @@ public class MainViewModel : INotifyPropertyChanged
         ventana.ShowDialog();
     }
 
+    private bool Validar(out string mensaje)
+    {
+        List<string> errores = [];
+        if (VisitasASimular < 10)
+            errores.Add("Visitas a simular debe ser al menos 10.");
+        if (DesdeVisita < 1)
+            errores.Add("Desde visita debe ser mayor o igual a 1.");
+        if (HastaVisita < DesdeVisita)
+            errores.Add("Hasta visita debe ser mayor o igual a Desde visita.");
+        if (HastaVisita > VisitasASimular)
+            errores.Add("Hasta visita no puede superar las visitas a simular.");
+        if (HastaVisita - DesdeVisita > 10000)
+            errores.Add("El rango de visitas para la tabla no puede exceder 10 000.");
+        if (ProbabilidadRecuerda <= 0 || ProbabilidadRecuerda >= 1)
+            errores.Add("La probabilidad de recordar debe estar entre 0 y 1.");
+        if (ProbabilidadDudosoCompra <= 0 || ProbabilidadDudosoCompra >= 1)
+            errores.Add("La probabilidad de compra para dudosos debe estar entre 0 y 1.");
+        if (VentasObjetivo <= 0)
+            errores.Add("Las ventas objetivo deben ser mayores que 0.");
+        if (SemillaRng is < int.MinValue or > int.MaxValue)
+            errores.Add("La semilla RNG debe estar dentro del rango de 32 bits.");
+        if (!ValidarFila(TablaRecuerda[0], out string errRec))
+            errores.Add($"Tabla 'Recuerda': {errRec}");
+        if (!ValidarFila(TablaNoRecuerda[0], out string errNoRec))
+            errores.Add($"Tabla 'No recuerda': {errNoRec}");
+        mensaje = string.Join("\n", errores);
+        return errores.Count == 0;
+    }
+
+    private static bool ValidarFila(ProbabilidadesFila fila, out string error)
+    {
+        string eNo = fila[nameof(ProbabilidadesFila.No)];
+        string eDu = fila[nameof(ProbabilidadesFila.Dudoso)];
+        string eSi = fila[nameof(ProbabilidadesFila.Si)];
+        if (!string.IsNullOrEmpty(eNo)) { error = eNo; return false; }
+        if (!string.IsNullOrEmpty(eDu)) { error = eDu; return false; }
+        if (!string.IsNullOrEmpty(eSi)) { error = eSi; return false; }
+        error = string.Empty; return true;
+    }
+
     public event PropertyChangedEventHandler? PropertyChanged;
-    private void OnPropertyChanged(string prop) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+    private void OnPropertyChanged(string prop)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+        CommandManager.InvalidateRequerySuggested();
+    }
 }

--- a/SimulacionCmiWPF/MainWindow.xaml
+++ b/SimulacionCmiWPF/MainWindow.xaml
@@ -28,10 +28,12 @@
           <ColumnDefinition Width="60"/>
           <ColumnDefinition Width="Auto"/>
           <ColumnDefinition Width="80"/>
+          <ColumnDefinition Width="Auto"/>
+          <ColumnDefinition Width="80"/>
         </Grid.ColumnDefinitions>
 
         <TextBlock Text="Visitas:" VerticalAlignment="Center"/>
-        <TextBox Grid.Column="1" Width="80" Margin="5,0" Text="{Binding Visitas}"/>
+        <TextBox Grid.Column="1" Width="80" Margin="5,0" Text="{Binding VisitasASimular}"/>
 
         <TextBlock Grid.Column="2" Text="Desde:" VerticalAlignment="Center" Margin="10,0,0,0"/>
         <TextBox Grid.Column="3" Width="60" Margin="5,0" Text="{Binding DesdeVisita}"/>
@@ -47,6 +49,9 @@
 
         <TextBlock Grid.Column="10" Text="Ventas objetivo:" VerticalAlignment="Center" Margin="10,0,0,0"/>
         <xctk:IntegerUpDown Grid.Column="11" Width="80" Margin="5,0" Minimum="1" Value="{Binding VentasObjetivo}"/>
+
+        <TextBlock Grid.Column="12" Text="Semilla RNG:" VerticalAlignment="Center" Margin="10,0,0,0"/>
+        <xctk:IntegerUpDown Grid.Column="13" Width="80" Margin="5,0" Value="{Binding SemillaRng}"/>
       </Grid>
     </DockPanel>
 


### PR DESCRIPTION
## Resumen
- Añadida entrada para semilla RNG en la ventana principal y propiedad enlazada en el ViewModel.
- Incorporadas validaciones exhaustivas para parámetros numéricos y tablas de probabilidades, con bloqueo del comando cuando hay errores.
- Documentados en el README los rangos permitidos para cada parámetro de la simulación.

## Pruebas
- `DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build SimulacionCmiCore/SimulacionCmiCore.csproj`
- `DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet test SimulacionCmiCore.Tests/SimulacionCmiCore.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688ffa81f85c8332b21831c590b03bfe