### PR TITLE
Pulido de UI y gráficos

### DIFF
--- a/SimulacionCmiWPF/GraficosViewModel.cs
+++ b/SimulacionCmiWPF/GraficosViewModel.cs
@@ -11,10 +11,17 @@ public class GraficosViewModel
 {
     public double[] VentasAcumuladas { get; }
     public double[] ProbabilidadSi { get; }
+    public int PrimeraVisita { get; }
+    public int UltimaVisita { get; }
 
     public GraficosViewModel(IList<VectorEstado> vectores)
     {
         VentasAcumuladas = vectores.Select(v => (double)v.VentasAcum).ToArray();
         ProbabilidadSi = vectores.Select(v => v.ProbAcumSi).ToArray();
+        if (vectores.Count > 0)
+        {
+            PrimeraVisita = vectores[0].Visita;
+            UltimaVisita = vectores[^1].Visita;
+        }
     }
 }

--- a/SimulacionCmiWPF/MainWindow.xaml
+++ b/SimulacionCmiWPF/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
-        Title="Simulación CMI" Height="720" Width="1280">
+        Title="Simulación CMI" Height="300" Width="600">
   <Grid Margin="8">
     <Grid.RowDefinitions>
       <RowDefinition Height="*"/>

--- a/SimulacionCmiWPF/MainWindow.xaml
+++ b/SimulacionCmiWPF/MainWindow.xaml
@@ -2,88 +2,74 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
-        Title="Simulación CMI" Height="600" Width="900">
-  <Grid Margin="10">
+        Title="Simulación CMI" Height="720" Width="1280">
+  <Grid Margin="8">
     <Grid.RowDefinitions>
-      <RowDefinition Height="Auto"/>
       <RowDefinition Height="*"/>
+      <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
-
-    <DockPanel Margin="0,0,0,10">
-      <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
-        <Button Content="Ejecutar simulación" Margin="5,0" Command="{Binding EjecutarSimulacion}"/>
-        <Button Content="Ver enunciado" Margin="5,0" Command="{Binding MostrarEnunciado}"/>
-      </StackPanel>
-      <Grid>
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="80"/>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="60"/>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="60"/>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="60"/>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="60"/>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="80"/>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="80"/>
-        </Grid.ColumnDefinitions>
-
-        <TextBlock Text="Visitas:" VerticalAlignment="Center"/>
-        <TextBox Grid.Column="1" Width="80" Margin="5,0" Text="{Binding VisitasASimular}"/>
-
-        <TextBlock Grid.Column="2" Text="Desde:" VerticalAlignment="Center" Margin="10,0,0,0"/>
-        <TextBox Grid.Column="3" Width="60" Margin="5,0" Text="{Binding DesdeVisita}"/>
-
-        <TextBlock Grid.Column="4" Text="Hasta:" VerticalAlignment="Center" Margin="10,0,0,0"/>
-        <TextBox Grid.Column="5" Width="60" Margin="5,0" Text="{Binding HastaVisita}"/>
-
-        <TextBlock Grid.Column="6" Text="P(Recuerda):" VerticalAlignment="Center" Margin="10,0,0,0"/>
-        <TextBox Grid.Column="7" Width="60" Margin="5,0" Text="{Binding ProbabilidadRecuerda}"/>
-
-        <TextBlock Grid.Column="8" Text="P(Compra|Dudoso):" VerticalAlignment="Center" Margin="10,0,0,0"/>
-        <TextBox Grid.Column="9" Width="60" Margin="5,0" Text="{Binding ProbabilidadDudosoCompra}"/>
-
-        <TextBlock Grid.Column="10" Text="Ventas objetivo:" VerticalAlignment="Center" Margin="10,0,0,0"/>
-        <xctk:IntegerUpDown Grid.Column="11" Width="80" Margin="5,0" Minimum="1" Value="{Binding VentasObjetivo}"/>
-
-        <TextBlock Grid.Column="12" Text="Semilla RNG:" VerticalAlignment="Center" Margin="10,0,0,0"/>
-        <xctk:IntegerUpDown Grid.Column="13" Width="80" Margin="5,0" Value="{Binding SemillaRng}"/>
-      </Grid>
-    </DockPanel>
-
-    <Grid Grid.Row="1">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="Auto"/>
-        <RowDefinition Height="*"/>
-      </Grid.RowDefinitions>
+    <Grid>
       <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="*"/>
+        <ColumnDefinition Width="Auto"/>
         <ColumnDefinition Width="*"/>
       </Grid.ColumnDefinitions>
 
-      <TextBlock Grid.Row="0" Grid.Column="0" Text="Probabilidades si RECUERDA" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,5"/>
-      <TextBlock Grid.Row="0" Grid.Column="1" Text="Probabilidades si NO RECUERDA" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,5"/>
+      <StackPanel Grid.Column="0" Orientation="Vertical" Margin="0,0,8,0">
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+          <TextBlock Text="Visitas:" VerticalAlignment="Center"/>
+          <TextBox Width="80" Margin="5,0,0,0" Text="{Binding VisitasASimular}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+          <TextBlock Text="Desde:" VerticalAlignment="Center"/>
+          <TextBox Width="60" Margin="5,0,0,0" Text="{Binding DesdeVisita}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+          <TextBlock Text="Hasta:" VerticalAlignment="Center"/>
+          <TextBox Width="60" Margin="5,0,0,0" Text="{Binding HastaVisita}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+          <TextBlock Text="P(Recuerda):" VerticalAlignment="Center"/>
+          <TextBox Width="60" Margin="5,0,0,0" Text="{Binding ProbabilidadRecuerda}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+          <TextBlock Text="P(Compra|Dudoso):" VerticalAlignment="Center"/>
+          <TextBox Width="60" Margin="5,0,0,0" Text="{Binding ProbabilidadDudosoCompra}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+          <TextBlock Text="Ventas objetivo:" VerticalAlignment="Center"/>
+          <xctk:IntegerUpDown Width="80" Margin="5,0,0,0" Minimum="1" Value="{Binding VentasObjetivo}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal">
+          <TextBlock Text="Semilla RNG:" VerticalAlignment="Center"/>
+          <xctk:IntegerUpDown Width="80" Margin="5,0,0,0" Value="{Binding SemillaRng}"/>
+        </StackPanel>
+      </StackPanel>
 
-      <DataGrid Grid.Row="1" Grid.Column="0" ItemsSource="{Binding TablaRecuerda}" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False">
-        <DataGrid.Columns>
-          <DataGridTextColumn Header="No" Binding="{Binding No, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-          <DataGridTextColumn Header="Dudoso" Binding="{Binding Dudoso, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-          <DataGridTextColumn Header="Sí" Binding="{Binding Si, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-        </DataGrid.Columns>
-      </DataGrid>
-
-      <DataGrid Grid.Row="1" Grid.Column="1" ItemsSource="{Binding TablaNoRecuerda}" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False">
-        <DataGrid.Columns>
-          <DataGridTextColumn Header="No" Binding="{Binding No, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-          <DataGridTextColumn Header="Dudoso" Binding="{Binding Dudoso, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-          <DataGridTextColumn Header="Sí" Binding="{Binding Si, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-        </DataGrid.Columns>
-      </DataGrid>
+      <StackPanel Grid.Column="1" Orientation="Vertical">
+        <GroupBox Header="Probabilidades si RECUERDA" Margin="0,0,0,8">
+          <DataGrid ItemsSource="{Binding TablaRecuerda}" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False">
+            <DataGrid.Columns>
+              <DataGridTextColumn Header="No" Binding="{Binding No, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+              <DataGridTextColumn Header="Dudoso" Binding="{Binding Dudoso, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+              <DataGridTextColumn Header="Sí" Binding="{Binding Si, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+            </DataGrid.Columns>
+          </DataGrid>
+        </GroupBox>
+        <GroupBox Header="Probabilidades si NO RECUERDA">
+          <DataGrid ItemsSource="{Binding TablaNoRecuerda}" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False">
+            <DataGrid.Columns>
+              <DataGridTextColumn Header="No" Binding="{Binding No, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+              <DataGridTextColumn Header="Dudoso" Binding="{Binding Dudoso, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+              <DataGridTextColumn Header="Sí" Binding="{Binding Si, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+            </DataGrid.Columns>
+          </DataGrid>
+        </GroupBox>
+      </StackPanel>
     </Grid>
+
+    <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+      <Button Content="Ejecutar simulación" Margin="0,0,8,0" Command="{Binding EjecutarSimulacion}"/>
+      <Button Content="Ver enunciado" Command="{Binding MostrarEnunciado}"/>
+    </StackPanel>
   </Grid>
 </Window>
-

--- a/SimulacionCmiWPF/VentanaEnunciado.xaml
+++ b/SimulacionCmiWPF/VentanaEnunciado.xaml
@@ -2,7 +2,31 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Enunciado" Height="450" Width="800" WindowStartupLocation="CenterOwner">
-  <ScrollViewer Margin="10">
-    <TextBlock x:Name="txtEnunciado" TextWrapping="Wrap"/>
+  <ScrollViewer Margin="8">
+    <TextBlock TextWrapping="Wrap">
+      CMI Corporation llevó a cabo una prueba para evaluar la efectividad de un nuevo anuncio por televisión para uno de sus productos domésticos. El anuncio se mostró en un mercado de prueba durante dos semanas. En el estudio de seguimiento se contactó telefónicamente con una selección aleatoria de personas y se les hizo una serie de preguntas sobre la posible compra del producto.
+      <LineBreak/><LineBreak/>
+      Probabilidades a priori
+      <LineBreak/>
+      Evento                     Probabilidad
+      <LineBreak/>
+      El individuo recordaba el mensaje      0,35
+      <LineBreak/>
+      El individuo no podía recordar el mensaje      0,65
+      <LineBreak/><LineBreak/>
+      Probabilidades condicionales
+      <LineBreak/>
+                               Definitivamente no   Dudoso   Definitivamente sí
+      <LineBreak/>
+      Podía recordar el mensaje         0,55            0,15     0,30
+      <LineBreak/>
+      No podía recordar el mensaje      0,70            0,25     0,05
+      <LineBreak/><LineBreak/>
+      Los objetivos del estudio son:
+      <LineBreak/>
+      1. Estimar por simulación la probabilidad general de que un individuo responda "definitivamente sí".
+      <LineBreak/>
+      2. Si el 60 % de los que respondieron "dudoso" terminan comprando, determinar cuántas visitas se necesitan para vender 10 000 productos.
+    </TextBlock>
   </ScrollViewer>
 </Window>

--- a/SimulacionCmiWPF/VentanaEnunciado.xaml.cs
+++ b/SimulacionCmiWPF/VentanaEnunciado.xaml.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Windows;
 
 namespace SimulacionCmiWPF;
@@ -11,15 +10,5 @@ public partial class VentanaEnunciado : Window
     public VentanaEnunciado()
     {
         InitializeComponent();
-        CargarEnunciado();
-    }
-
-    private void CargarEnunciado()
-    {
-        string ruta = Path.Combine(AppContext.BaseDirectory, "README.md");
-        if (File.Exists(ruta))
-            txtEnunciado.Text = File.ReadAllText(ruta);
-        else
-            txtEnunciado.Text = "README no encontrado.";
     }
 }

--- a/SimulacionCmiWPF/VentanaGraficos.xaml
+++ b/SimulacionCmiWPF/VentanaGraficos.xaml
@@ -3,12 +3,12 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:wpf="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
         Title="Gráficos" Height="500" Width="800" WindowStartupLocation="CenterOwner">
-  <Grid Margin="10">
+  <Grid Margin="8">
     <Grid.RowDefinitions>
       <RowDefinition Height="*"/>
       <RowDefinition Height="*"/>
     </Grid.RowDefinitions>
     <wpf:WpfPlot x:Name="plotVentas" Grid.Row="0"/>
-    <wpf:WpfPlot x:Name="plotProbabilidad" Grid.Row="1" Margin="0,10,0,0"/>
+    <wpf:WpfPlot x:Name="plotProbabilidad" Grid.Row="1" Margin="0,8,0,0"/>
   </Grid>
 </Window>

--- a/SimulacionCmiWPF/VentanaGraficos.xaml.cs
+++ b/SimulacionCmiWPF/VentanaGraficos.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Windows;
 using ScottPlot;
@@ -20,13 +21,28 @@ public partial class VentanaGraficos : Window
         if (DataContext is not GraficosViewModel vm)
             return;
 
-        double[] xs = Enumerable.Range(1, vm.VentasAcumuladas.Length).Select(i => (double)i).ToArray();
+        double[] xs = Enumerable.Range(vm.PrimeraVisita, vm.VentasAcumuladas.Length)
+            .Select(i => (double)i).ToArray();
+
         plotVentas.Plot.Add.Scatter(xs, vm.VentasAcumuladas);
         plotVentas.Plot.Title("Ventas acumuladas");
+        plotVentas.Plot.Axes.SetLimits(vm.PrimeraVisita, vm.UltimaVisita);
         plotVentas.Refresh();
 
-        plotProbabilidad.Plot.Add.Scatter(xs, vm.ProbabilidadSi);
+        double[] logProb = vm.ProbabilidadSi
+            .Select(p => Math.Log10(Math.Max(p, 1e-3)))
+            .ToArray();
+        plotProbabilidad.Plot.Add.Scatter(xs, logProb);
         plotProbabilidad.Plot.Title("P(Def. Sí)");
+        plotProbabilidad.Plot.Axes.SetLimits(vm.PrimeraVisita, vm.UltimaVisita, -3, 0);
+
+        var ticks = new ScottPlot.TickGenerators.NumericAutomatic
+        {
+            LabelFormatter = v => Math.Pow(10, v).ToString("0.###"),
+            MinorTickGenerator = new ScottPlot.TickGenerators.EvenlySpacedMinorTickGenerator(0.05),
+            MaxTickCount = 4
+        };
+        plotProbabilidad.Plot.Axes.Left.TickGenerator = ticks;
         plotProbabilidad.Refresh();
     }
 }

--- a/SimulacionCmiWPF/VentanaResultados.xaml
+++ b/SimulacionCmiWPF/VentanaResultados.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="SimulacionCmiWPF.VentanaResultados"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Resultados" Height="500" Width="900" WindowStartupLocation="CenterOwner">
+        Title="Resultados" Height="500" Width="1100" WindowStartupLocation="CenterOwner">
   <Grid Margin="10">
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Resumen
- Se incorpora el enunciado completo de CMI en la ventana de ayuda con desplazamiento.
- Reorganización de la ventana principal: parámetros numéricos en panel vertical y tablas de probabilidades en GroupBoxes apilados.
- Ajustes gráficos: límites de ejes según visitas, escala logarítmica para P("Def. Sí") y ticks personalizados.

## Pruebas
- `dotnet build SimulacionCmiCore/SimulacionCmiCore.csproj`
- `dotnet test SimulacionCmiCore.Tests/SimulacionCmiCore.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6890007510cc8332adb4387262b6b391