### PR TITLE
Agregar resumen final y formato de tablas

### DIFF
--- a/SimulacionCmiWPF/ResultadosViewModel.cs
+++ b/SimulacionCmiWPF/ResultadosViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
@@ -13,6 +14,10 @@ public class ResultadosViewModel
 {
     public IList<VectorEstado> Vectores { get; }
     public VectorEstado Ultimo { get; }
+    // NUEVO: envoltorio enumerable para el DataGrid
+    public IEnumerable<VectorEstado> UltimaFila =>
+        Ultimo is null ? Array.Empty<VectorEstado>()
+                       : new[] { Ultimo };
     public double ProbabilidadSi { get; }
     public int VentasTotales { get; }
     public int? VisitaObjetivo { get; }

--- a/SimulacionCmiWPF/VentanaEnunciado.xaml
+++ b/SimulacionCmiWPF/VentanaEnunciado.xaml
@@ -3,30 +3,52 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Enunciado" Height="450" Width="800" WindowStartupLocation="CenterOwner">
   <ScrollViewer Margin="8">
-    <TextBlock TextWrapping="Wrap">
-      CMI Corporation llevó a cabo una prueba para evaluar la efectividad de un nuevo anuncio por televisión para uno de sus productos domésticos. El anuncio se mostró en un mercado de prueba durante dos semanas. En el estudio de seguimiento se contactó telefónicamente con una selección aleatoria de personas y se les hizo una serie de preguntas sobre la posible compra del producto.
-      <LineBreak/><LineBreak/>
-      Probabilidades a priori
-      <LineBreak/>
-      Evento                     Probabilidad
-      <LineBreak/>
-      El individuo recordaba el mensaje      0,35
-      <LineBreak/>
-      El individuo no podía recordar el mensaje      0,65
-      <LineBreak/><LineBreak/>
-      Probabilidades condicionales
-      <LineBreak/>
-                               Definitivamente no   Dudoso   Definitivamente sí
-      <LineBreak/>
-      Podía recordar el mensaje         0,55            0,15     0,30
-      <LineBreak/>
-      No podía recordar el mensaje      0,70            0,25     0,05
-      <LineBreak/><LineBreak/>
-      Los objetivos del estudio son:
-      <LineBreak/>
-      1. Estimar por simulación la probabilidad general de que un individuo responda "definitivamente sí".
-      <LineBreak/>
-      2. Si el 60 % de los que respondieron "dudoso" terminan comprando, determinar cuántas visitas se necesitan para vender 10 000 productos.
-    </TextBlock>
+    <StackPanel>
+      <TextBlock TextWrapping="Wrap">
+        CMI Corporation llevó a cabo una prueba para evaluar la efectividad de un nuevo anuncio por televisión para uno de sus productos domésticos. El anuncio se mostró en un mercado de prueba durante dos semanas. En el estudio de seguimiento se contactó telefónicamente con una selección aleatoria de personas y se les hizo una serie de preguntas sobre la posible compra del producto.
+        <LineBreak/><LineBreak/>
+        Los objetivos del estudio son:
+        <LineBreak/>
+        1. Estimar por simulación la probabilidad general de que un individuo responda "definitivamente sí".
+        <LineBreak/>
+        2. Si el 60 % de los que respondieron "dudoso" terminan comprando, determinar cuántas visitas se necesitan para vender 10 000 productos.
+      </TextBlock>
+
+      <TextBlock Margin="0,8,0,0" Text="Probabilidades a priori" FontWeight="Bold"/>
+      <Grid Margin="0,4,0,0">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*"/>
+          <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <TextBlock Text="Evento" FontWeight="Bold"/>
+        <TextBlock Text="Probabilidad" Grid.Column="1" FontWeight="Bold"/>
+        <TextBlock Grid.Row="1" Text="El individuo recordaba el mensaje"/>
+        <TextBlock Grid.Row="1" Grid.Column="1" Text="0,35" TextAlignment="Right"/>
+        <TextBlock Grid.Row="2" Text="El individuo no podía recordar el mensaje"/>
+        <TextBlock Grid.Row="2" Grid.Column="1" Text="0,65" TextAlignment="Right"/>
+      </Grid>
+
+      <TextBlock Margin="0,8,0,0" Text="Probabilidades condicionales" FontWeight="Bold"/>
+      <Grid Margin="0,4,0,0">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*"/>
+          <ColumnDefinition Width="Auto"/>
+          <ColumnDefinition Width="Auto"/>
+          <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <TextBlock Text="Evento" FontWeight="Bold"/>
+        <TextBlock Grid.Column="1" Text="Def. No" FontWeight="Bold" TextAlignment="Right"/>
+        <TextBlock Grid.Column="2" Text="Dudoso" FontWeight="Bold" TextAlignment="Right"/>
+        <TextBlock Grid.Column="3" Text="Def. Sí" FontWeight="Bold" TextAlignment="Right"/>
+        <TextBlock Grid.Row="1" Text="Podía recordar el mensaje"/>
+        <TextBlock Grid.Row="1" Grid.Column="1" Text="0,55" TextAlignment="Right"/>
+        <TextBlock Grid.Row="1" Grid.Column="2" Text="0,15" TextAlignment="Right"/>
+        <TextBlock Grid.Row="1" Grid.Column="3" Text="0,30" TextAlignment="Right"/>
+        <TextBlock Grid.Row="2" Text="No podía recordar el mensaje"/>
+        <TextBlock Grid.Row="2" Grid.Column="1" Text="0,70" TextAlignment="Right"/>
+        <TextBlock Grid.Row="2" Grid.Column="2" Text="0,25" TextAlignment="Right"/>
+        <TextBlock Grid.Row="2" Grid.Column="3" Text="0,05" TextAlignment="Right"/>
+      </Grid>
+    </StackPanel>
   </ScrollViewer>
 </Window>

--- a/SimulacionCmiWPF/VentanaResultados.xaml
+++ b/SimulacionCmiWPF/VentanaResultados.xaml
@@ -16,22 +16,29 @@
       <Run Text="  |  P(Def. Sí): "/>
       <Run Text="{Binding ProbabilidadSi, StringFormat=F4, Mode=OneWay}"/>
     </TextBlock>
-    <DataGrid Grid.Row="1" ItemsSource="{Binding Vectores}" AutoGenerateColumns="False" IsReadOnly="True">
-      <DataGrid.Columns>
-        <DataGridTextColumn Header="Visita" Binding="{Binding Visita}" Width="60"/>
-        <DataGridTextColumn Header="Rnd Recuerda" Binding="{Binding RndRecuerda, StringFormat=F4}" Width="90"/>
-        <DataGridTextColumn Header="Recuerda" Binding="{Binding Recuerda}" Width="80"/>
-        <DataGridTextColumn Header="Rnd Respuesta" Binding="{Binding RndRespuesta, StringFormat=F4}" Width="90"/>
-        <DataGridTextColumn Header="Respuesta" Binding="{Binding Respuesta}" Width="120"/>
-        <DataGridTextColumn Header="Rnd Compra" Binding="{Binding RndCompra, StringFormat=F4}" Width="90"/>
-        <DataGridTextColumn Header="Compra" Binding="{Binding Compra}" Width="80"/>
-        <DataGridTextColumn Header="Acum Sí" Binding="{Binding AcumSi}" Width="80"/>
-        <DataGridTextColumn Header="Acum No" Binding="{Binding AcumNo}" Width="80"/>
-        <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
-        <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
-        <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
-      </DataGrid.Columns>
-    </DataGrid>
+    <Grid Grid.Row="1">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="*"/>
+        <RowDefinition Height="Auto"/>
+      </Grid.RowDefinitions>
+      <DataGrid Grid.Row="0" ItemsSource="{Binding Vectores}" AutoGenerateColumns="False" IsReadOnly="True">
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="Visita" Binding="{Binding Visita}" Width="60"/>
+          <DataGridTextColumn Header="Rnd Recuerda" Binding="{Binding RndRecuerda, StringFormat=F4}" Width="90"/>
+          <DataGridTextColumn Header="Recuerda" Binding="{Binding Recuerda}" Width="80"/>
+          <DataGridTextColumn Header="Rnd Respuesta" Binding="{Binding RndRespuesta, StringFormat=F4}" Width="90"/>
+          <DataGridTextColumn Header="Respuesta" Binding="{Binding Respuesta}" Width="120"/>
+          <DataGridTextColumn Header="Rnd Compra" Binding="{Binding RndCompra, StringFormat=F4}" Width="90"/>
+          <DataGridTextColumn Header="Compra" Binding="{Binding Compra}" Width="80"/>
+          <DataGridTextColumn Header="Acum Sí" Binding="{Binding AcumSi}" Width="80"/>
+          <DataGridTextColumn Header="Acum No" Binding="{Binding AcumNo}" Width="80"/>
+          <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
+          <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
+          <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
+        </DataGrid.Columns>
+      </DataGrid>
+      <DataGrid Grid.Row="1" ItemsSource="{Binding UltimaFila}" AutoGenerateColumns="True" IsReadOnly="True"/>
+    </Grid>
     <Button Grid.Row="2" Content="Ver gráficos" HorizontalAlignment="Right" Margin="0,10,0,0" Command="{Binding MostrarGraficos}"/>
   </Grid>
 </Window>


### PR DESCRIPTION
## Resumen
- Exponer la última fila simulada mediante la propiedad `UltimaFila` para facilitar el enlace en la vista.
- Mostrar un segundo `DataGrid` en la ventana de resultados con la última fila de la simulación.
- Reestructurar la ventana de enunciado con un `StackPanel` y tablas bien maquetadas para probabilidades a priori y condicionales.

## Testing
- `dotnet test` *(falla al compilar el proyecto WPF por falta de `Microsoft.NET.Sdk.WindowsDesktop`, pero las pruebas de `SimulacionCmiCore` se ejecutan y pasan: 3 tests)*


------
https://chatgpt.com/codex/tasks/task_e_6890071f6ec88332a00ad2e435aa3557