### PR TITLE
Agregar resumen final y maquetar tablas del enunciado

### DIFF
--- a/SimulacionCmiWPF/ResultadosViewModel.cs
+++ b/SimulacionCmiWPF/ResultadosViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
@@ -13,6 +14,12 @@ public class ResultadosViewModel
 {
     public IList<VectorEstado> Vectores { get; }
     public VectorEstado Ultimo { get; }
+
+    // NUEVO: envoltorio enumerable para el DataGrid
+    public IEnumerable<VectorEstado> UltimaFila =>
+        Ultimo is null ? Array.Empty<VectorEstado>()
+                       : new[] { Ultimo };
+
     public double ProbabilidadSi { get; }
     public int VentasTotales { get; }
     public int? VisitaObjetivo { get; }

--- a/SimulacionCmiWPF/VentanaEnunciado.xaml
+++ b/SimulacionCmiWPF/VentanaEnunciado.xaml
@@ -3,30 +3,63 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Enunciado" Height="450" Width="800" WindowStartupLocation="CenterOwner">
   <ScrollViewer Margin="8">
-    <TextBlock TextWrapping="Wrap">
-      CMI Corporation llevó a cabo una prueba para evaluar la efectividad de un nuevo anuncio por televisión para uno de sus productos domésticos. El anuncio se mostró en un mercado de prueba durante dos semanas. En el estudio de seguimiento se contactó telefónicamente con una selección aleatoria de personas y se les hizo una serie de preguntas sobre la posible compra del producto.
-      <LineBreak/><LineBreak/>
-      Probabilidades a priori
-      <LineBreak/>
-      Evento                     Probabilidad
-      <LineBreak/>
-      El individuo recordaba el mensaje      0,35
-      <LineBreak/>
-      El individuo no podía recordar el mensaje      0,65
-      <LineBreak/><LineBreak/>
-      Probabilidades condicionales
-      <LineBreak/>
-                               Definitivamente no   Dudoso   Definitivamente sí
-      <LineBreak/>
-      Podía recordar el mensaje         0,55            0,15     0,30
-      <LineBreak/>
-      No podía recordar el mensaje      0,70            0,25     0,05
-      <LineBreak/><LineBreak/>
-      Los objetivos del estudio son:
-      <LineBreak/>
-      1. Estimar por simulación la probabilidad general de que un individuo responda "definitivamente sí".
-      <LineBreak/>
-      2. Si el 60 % de los que respondieron "dudoso" terminan comprando, determinar cuántas visitas se necesitan para vender 10 000 productos.
-    </TextBlock>
+    <StackPanel>
+      <TextBlock TextWrapping="Wrap">
+        CMI Corporation llevó a cabo una prueba para evaluar la efectividad de un nuevo anuncio por televisión para uno de sus productos domésticos. El anuncio se mostró en un mercado de prueba durante dos semanas. En el estudio de seguimiento se contactó telefónicamente con una selección aleatoria de personas y se les hizo una serie de preguntas sobre la posible compra del producto.
+        <LineBreak/><LineBreak/>
+        Los objetivos del estudio son:
+        <LineBreak/>
+        1. Estimar por simulación la probabilidad general de que un individuo responda "definitivamente sí".
+        <LineBreak/>
+        2. Si el 60 % de los que respondieron "dudoso" terminan comprando, determinar cuántas visitas se necesitan para vender 10000 productos.
+      </TextBlock>
+
+      <TextBlock Text="Probabilidades a priori" FontWeight="Bold" Margin="0,12,0,4"/>
+      <Grid Margin="0,0,0,8">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition/>
+          <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+          <RowDefinition/>
+          <RowDefinition/>
+          <RowDefinition/>
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold">Evento</TextBlock>
+        <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold" TextAlignment="Right">Probabilidad</TextBlock>
+        <TextBlock Grid.Row="1" Grid.Column="0">El individuo recordaba el mensaje</TextBlock>
+        <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Right">0,35</TextBlock>
+        <TextBlock Grid.Row="2" Grid.Column="0">El individuo no podía recordar el mensaje</TextBlock>
+        <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Right">0,65</TextBlock>
+      </Grid>
+
+      <TextBlock Text="Probabilidades condicionales" FontWeight="Bold" Margin="0,12,0,4"/>
+      <Grid>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition/>
+          <ColumnDefinition Width="Auto"/>
+          <ColumnDefinition Width="Auto"/>
+          <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+          <RowDefinition/>
+          <RowDefinition/>
+          <RowDefinition/>
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold">Evento</TextBlock>
+        <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold" TextAlignment="Right">Def. No</TextBlock>
+        <TextBlock Grid.Row="0" Grid.Column="2" FontWeight="Bold" TextAlignment="Right">Dudoso</TextBlock>
+        <TextBlock Grid.Row="0" Grid.Column="3" FontWeight="Bold" TextAlignment="Right">Def. Sí</TextBlock>
+        <TextBlock Grid.Row="1" Grid.Column="0">Podía recordar el mensaje</TextBlock>
+        <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Right">0,55</TextBlock>
+        <TextBlock Grid.Row="1" Grid.Column="2" TextAlignment="Right">0,15</TextBlock>
+        <TextBlock Grid.Row="1" Grid.Column="3" TextAlignment="Right">0,30</TextBlock>
+        <TextBlock Grid.Row="2" Grid.Column="0">No podía recordar el mensaje</TextBlock>
+        <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Right">0,70</TextBlock>
+        <TextBlock Grid.Row="2" Grid.Column="2" TextAlignment="Right">0,25</TextBlock>
+        <TextBlock Grid.Row="2" Grid.Column="3" TextAlignment="Right">0,05</TextBlock>
+      </Grid>
+    </StackPanel>
   </ScrollViewer>
 </Window>
+

--- a/SimulacionCmiWPF/VentanaResultados.xaml
+++ b/SimulacionCmiWPF/VentanaResultados.xaml
@@ -21,23 +21,42 @@
         <RowDefinition Height="*"/>
         <RowDefinition Height="Auto"/>
       </Grid.RowDefinitions>
-      <DataGrid Grid.Row="0" ItemsSource="{Binding Vectores}" AutoGenerateColumns="False" IsReadOnly="True">
-        <DataGrid.Columns>
-          <DataGridTextColumn Header="Visita" Binding="{Binding Visita}" Width="60"/>
-          <DataGridTextColumn Header="Rnd Recuerda" Binding="{Binding RndRecuerda, StringFormat=F4}" Width="90"/>
-          <DataGridTextColumn Header="Recuerda" Binding="{Binding Recuerda}" Width="80"/>
-          <DataGridTextColumn Header="Rnd Respuesta" Binding="{Binding RndRespuesta, StringFormat=F4}" Width="90"/>
-          <DataGridTextColumn Header="Respuesta" Binding="{Binding Respuesta}" Width="120"/>
-          <DataGridTextColumn Header="Rnd Compra" Binding="{Binding RndCompra, StringFormat=F4}" Width="90"/>
-          <DataGridTextColumn Header="Compra" Binding="{Binding Compra}" Width="80"/>
-          <DataGridTextColumn Header="Acum Sí" Binding="{Binding AcumSi}" Width="80"/>
-          <DataGridTextColumn Header="Acum No" Binding="{Binding AcumNo}" Width="80"/>
-          <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
-          <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
-          <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
-        </DataGrid.Columns>
-      </DataGrid>
-      <DataGrid Grid.Row="1" ItemsSource="{Binding UltimaFila}" AutoGenerateColumns="True" IsReadOnly="True"/>
+      <GroupBox Grid.Row="0" Header="Vectores estado" Margin="0,0,0,8">
+        <DataGrid ItemsSource="{Binding Vectores}" AutoGenerateColumns="False" IsReadOnly="True">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="Visita" Binding="{Binding Visita}" Width="60"/>
+            <DataGridTextColumn Header="Rnd Recuerda" Binding="{Binding RndRecuerda, StringFormat=F4}" Width="90"/>
+            <DataGridTextColumn Header="Recuerda" Binding="{Binding Recuerda}" Width="80"/>
+            <DataGridTextColumn Header="Rnd Respuesta" Binding="{Binding RndRespuesta, StringFormat=F4}" Width="90"/>
+            <DataGridTextColumn Header="Respuesta" Binding="{Binding Respuesta}" Width="120"/>
+            <DataGridTextColumn Header="Rnd Compra" Binding="{Binding RndCompra, StringFormat=F4}" Width="90"/>
+            <DataGridTextColumn Header="Compra" Binding="{Binding Compra}" Width="80"/>
+            <DataGridTextColumn Header="Acum Sí" Binding="{Binding AcumSi}" Width="80"/>
+            <DataGridTextColumn Header="Acum No" Binding="{Binding AcumNo}" Width="80"/>
+            <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
+            <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
+            <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
+          </DataGrid.Columns>
+        </DataGrid>
+      </GroupBox>
+      <GroupBox Grid.Row="1" Header="Última Fila" Margin="0,0,0,8">
+        <DataGrid ItemsSource="{Binding UltimaFila}" AutoGenerateColumns="False" IsReadOnly="True">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="Visita" Binding="{Binding Visita}" Width="60"/>
+            <DataGridTextColumn Header="Rnd Recuerda" Binding="{Binding RndRecuerda, StringFormat=F4}" Width="90"/>
+            <DataGridTextColumn Header="Recuerda" Binding="{Binding Recuerda}" Width="80"/>
+            <DataGridTextColumn Header="Rnd Respuesta" Binding="{Binding RndRespuesta, StringFormat=F4}" Width="90"/>
+            <DataGridTextColumn Header="Respuesta" Binding="{Binding Respuesta}" Width="120"/>
+            <DataGridTextColumn Header="Rnd Compra" Binding="{Binding RndCompra, StringFormat=F4}" Width="90"/>
+            <DataGridTextColumn Header="Compra" Binding="{Binding Compra}" Width="80"/>
+            <DataGridTextColumn Header="Acum Sí" Binding="{Binding AcumSi}" Width="80"/>
+            <DataGridTextColumn Header="Acum No" Binding="{Binding AcumNo}" Width="80"/>
+            <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
+            <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
+            <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
+          </DataGrid.Columns>
+        </DataGrid>
+      </GroupBox>
     </Grid>
     <Button Grid.Row="2" Content="Ver gráficos" HorizontalAlignment="Right" Margin="0,10,0,0" Command="{Binding MostrarGraficos}"/>
   </Grid>

--- a/SimulacionCmiWPF/VentanaResultados.xaml
+++ b/SimulacionCmiWPF/VentanaResultados.xaml
@@ -16,22 +16,29 @@
       <Run Text="  |  P(Def. Sí): "/>
       <Run Text="{Binding ProbabilidadSi, StringFormat=F4, Mode=OneWay}"/>
     </TextBlock>
-    <DataGrid Grid.Row="1" ItemsSource="{Binding Vectores}" AutoGenerateColumns="False" IsReadOnly="True">
-      <DataGrid.Columns>
-        <DataGridTextColumn Header="Visita" Binding="{Binding Visita}" Width="60"/>
-        <DataGridTextColumn Header="Rnd Recuerda" Binding="{Binding RndRecuerda, StringFormat=F4}" Width="90"/>
-        <DataGridTextColumn Header="Recuerda" Binding="{Binding Recuerda}" Width="80"/>
-        <DataGridTextColumn Header="Rnd Respuesta" Binding="{Binding RndRespuesta, StringFormat=F4}" Width="90"/>
-        <DataGridTextColumn Header="Respuesta" Binding="{Binding Respuesta}" Width="120"/>
-        <DataGridTextColumn Header="Rnd Compra" Binding="{Binding RndCompra, StringFormat=F4}" Width="90"/>
-        <DataGridTextColumn Header="Compra" Binding="{Binding Compra}" Width="80"/>
-        <DataGridTextColumn Header="Acum Sí" Binding="{Binding AcumSi}" Width="80"/>
-        <DataGridTextColumn Header="Acum No" Binding="{Binding AcumNo}" Width="80"/>
-        <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
-        <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
-        <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
-      </DataGrid.Columns>
-    </DataGrid>
+    <Grid Grid.Row="1">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="*"/>
+        <RowDefinition Height="Auto"/>
+      </Grid.RowDefinitions>
+      <DataGrid Grid.Row="0" ItemsSource="{Binding Vectores}" AutoGenerateColumns="False" IsReadOnly="True">
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="Visita" Binding="{Binding Visita}" Width="60"/>
+          <DataGridTextColumn Header="Rnd Recuerda" Binding="{Binding RndRecuerda, StringFormat=F4}" Width="90"/>
+          <DataGridTextColumn Header="Recuerda" Binding="{Binding Recuerda}" Width="80"/>
+          <DataGridTextColumn Header="Rnd Respuesta" Binding="{Binding RndRespuesta, StringFormat=F4}" Width="90"/>
+          <DataGridTextColumn Header="Respuesta" Binding="{Binding Respuesta}" Width="120"/>
+          <DataGridTextColumn Header="Rnd Compra" Binding="{Binding RndCompra, StringFormat=F4}" Width="90"/>
+          <DataGridTextColumn Header="Compra" Binding="{Binding Compra}" Width="80"/>
+          <DataGridTextColumn Header="Acum Sí" Binding="{Binding AcumSi}" Width="80"/>
+          <DataGridTextColumn Header="Acum No" Binding="{Binding AcumNo}" Width="80"/>
+          <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
+          <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
+          <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
+        </DataGrid.Columns>
+      </DataGrid>
+      <DataGrid Grid.Row="1" ItemsSource="{Binding UltimaFila}" AutoGenerateColumns="True" IsReadOnly="True"/>
+    </Grid>
     <Button Grid.Row="2" Content="Ver gráficos" HorizontalAlignment="Right" Margin="0,10,0,0" Command="{Binding MostrarGraficos}"/>
   </Grid>
 </Window>


### PR DESCRIPTION
## Resumen
- Añade `UltimaFila` en `ResultadosViewModel` para exponer la última fila de datos.
- Inserta un segundo `DataGrid` en `VentanaResultados` que muestra el resumen final.
- Reestructura `VentanaEnunciado` con tablas a priori y condicionales claramente formateadas.

## Pruebas
- `dotnet test` *(falla: falta Microsoft.NET.Sdk.WindowsDesktop en el entorno Linux)*
- `dotnet test SimulacionCmiCore.Tests/SimulacionCmiCore.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6890071f6ec88332a00ad2e435aa3557