### PR TITLE
Agrega índice meta y muestra tablas con bordes

### DIFF
--- a/SimulacionCmiCore/MotorCmi.cs
+++ b/SimulacionCmiCore/MotorCmi.cs
@@ -41,7 +41,6 @@ public class MotorCmi
         var resultados = new List<VectorEstado>();
         VectorEstado? anterior = null;
         VectorEstado? actual = null;
-        int? visitaObjetivo = null;
 
         for (int i = 1; i <= visitas; i++)
         {
@@ -76,6 +75,10 @@ public class MotorCmi
             int acumDudoso = (anterior?.AcumDudoso ?? 0) + (respuesta == "Dudoso" ? 1 : 0);
             int ventas = (anterior?.VentasAcum ?? 0) + (compra ? 1 : 0);
 
+            int? indiceMeta = anterior?.IndiceMetaVentas;
+            if (indiceMeta is null && ventas >= _ventasObjetivo)
+                indiceMeta = i;
+
             actual = new VectorEstado
             {
                 Visita = i,
@@ -89,14 +92,12 @@ public class MotorCmi
                 AcumNo = acumNo,
                 AcumDudoso = acumDudoso,
                 ProbAcumSi = (double)acumSi / i,
-                VentasAcum = ventas
+                VentasAcum = ventas,
+                IndiceMetaVentas = indiceMeta
             };
 
             if (i >= desde && i <= hasta)
                 resultados.Add(actual.Clonar());
-
-            if (visitaObjetivo is null && ventas >= _ventasObjetivo)
-                visitaObjetivo = i;
 
             anterior = actual;
         }
@@ -105,6 +106,7 @@ public class MotorCmi
         VectorEstado ultimo = actual!;
         double probSi = (double)ultimo.AcumSi / ultimo.Visita;
         int ventasTotales = ultimo.VentasAcum;
+        int? visitaObjetivo = ultimo.IndiceMetaVentas;
         return (resultados, ultimo, probSi, ventasTotales, visitaObjetivo);
     }
 

--- a/SimulacionCmiCore/VectorEstado.cs
+++ b/SimulacionCmiCore/VectorEstado.cs
@@ -31,6 +31,13 @@ public class VectorEstado
     public int VentasAcum { get; set; }
 
     /// <summary>
+    /// Índice de la visita en la que se alcanza por primera vez el objetivo
+    /// de ventas. Permanece <c>null</c> hasta que dicho objetivo es alcanzado
+    /// y luego se propaga a los siguientes vectores.
+    /// </summary>
+    public int? IndiceMetaVentas { get; init; }
+
+    /// <summary>
     /// Crea una copia superficial del vector.
     /// </summary>
     public VectorEstado Clonar() => (VectorEstado)MemberwiseClone();

--- a/SimulacionCmiWPF/VentanaEnunciado.xaml
+++ b/SimulacionCmiWPF/VentanaEnunciado.xaml
@@ -15,50 +15,54 @@
       </TextBlock>
 
       <TextBlock Text="Probabilidades a priori" FontWeight="Bold" Margin="0,12,0,4"/>
-      <Grid Margin="0,0,0,8">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition/>
-          <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-          <RowDefinition/>
-          <RowDefinition/>
-          <RowDefinition/>
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold">Evento</TextBlock>
-        <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold" TextAlignment="Right">Probabilidad</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="0">El individuo recordaba el mensaje</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Right">0,35</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="0">El individuo no podía recordar el mensaje</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Right">0,65</TextBlock>
-      </Grid>
+      <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,0,8">
+        <Grid ShowGridLines="True">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition Width="Auto"/>
+          </Grid.ColumnDefinitions>
+          <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+            <RowDefinition/>
+          </Grid.RowDefinitions>
+          <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold">Evento</TextBlock>
+          <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold" TextAlignment="Right">Probabilidad</TextBlock>
+          <TextBlock Grid.Row="1" Grid.Column="0">El individuo recordaba el mensaje</TextBlock>
+          <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Right">0,35</TextBlock>
+          <TextBlock Grid.Row="2" Grid.Column="0">El individuo no podía recordar el mensaje</TextBlock>
+          <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Right">0,65</TextBlock>
+        </Grid>
+      </Border>
 
       <TextBlock Text="Probabilidades condicionales" FontWeight="Bold" Margin="0,12,0,4"/>
-      <Grid>
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition/>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-          <RowDefinition/>
-          <RowDefinition/>
-          <RowDefinition/>
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold">Evento</TextBlock>
-        <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold" TextAlignment="Right">Def. No</TextBlock>
-        <TextBlock Grid.Row="0" Grid.Column="2" FontWeight="Bold" TextAlignment="Right">Dudoso</TextBlock>
-        <TextBlock Grid.Row="0" Grid.Column="3" FontWeight="Bold" TextAlignment="Right">Def. Sí</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="0">Podía recordar el mensaje</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Right">0,55</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="2" TextAlignment="Right">0,15</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="3" TextAlignment="Right">0,30</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="0">No podía recordar el mensaje</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Right">0,70</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="2" TextAlignment="Right">0,25</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="3" TextAlignment="Right">0,05</TextBlock>
-      </Grid>
+      <Border BorderBrush="Gray" BorderThickness="1">
+        <Grid ShowGridLines="True">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
+          </Grid.ColumnDefinitions>
+          <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+            <RowDefinition/>
+          </Grid.RowDefinitions>
+          <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold">Evento</TextBlock>
+          <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold" TextAlignment="Right">Def. No</TextBlock>
+          <TextBlock Grid.Row="0" Grid.Column="2" FontWeight="Bold" TextAlignment="Right">Dudoso</TextBlock>
+          <TextBlock Grid.Row="0" Grid.Column="3" FontWeight="Bold" TextAlignment="Right">Def. Sí</TextBlock>
+          <TextBlock Grid.Row="1" Grid.Column="0">Podía recordar el mensaje</TextBlock>
+          <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Right">0,55</TextBlock>
+          <TextBlock Grid.Row="1" Grid.Column="2" TextAlignment="Right">0,15</TextBlock>
+          <TextBlock Grid.Row="1" Grid.Column="3" TextAlignment="Right">0,30</TextBlock>
+          <TextBlock Grid.Row="2" Grid.Column="0">No podía recordar el mensaje</TextBlock>
+          <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Right">0,70</TextBlock>
+          <TextBlock Grid.Row="2" Grid.Column="2" TextAlignment="Right">0,25</TextBlock>
+          <TextBlock Grid.Row="2" Grid.Column="3" TextAlignment="Right">0,05</TextBlock>
+        </Grid>
+      </Border>
     </StackPanel>
   </ScrollViewer>
 </Window>

--- a/SimulacionCmiWPF/VentanaResultados.xaml
+++ b/SimulacionCmiWPF/VentanaResultados.xaml
@@ -36,6 +36,10 @@
             <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
             <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
             <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
+            <DataGridTextColumn Header="Índice meta"
+                                Binding="{Binding IndiceMetaVentas}"
+                                Width="100"
+                                IsReadOnly="True"/>
           </DataGrid.Columns>
         </DataGrid>
       </GroupBox>
@@ -54,6 +58,10 @@
             <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
             <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
             <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
+            <DataGridTextColumn Header="Índice meta"
+                                Binding="{Binding IndiceMetaVentas}"
+                                Width="100"
+                                IsReadOnly="True"/>
           </DataGrid.Columns>
         </DataGrid>
       </GroupBox>


### PR DESCRIPTION
## Summary
- Muestra las tablas del enunciado con bordes y líneas de cuadrícula para una mejor lectura.
- Agrega la propiedad `IndiceMetaVentas` al vector de estado y la propaga durante la simulación.
- Expone el nuevo índice en los resultados mediante una columna explícita en ambos grids.

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68900c23b41c8332970a81e8068c108b