### PR TITLE
Agregar índice meta de ventas y mejorar tablas

### DIFF
--- a/SimulacionCmiCore/MotorCmi.cs
+++ b/SimulacionCmiCore/MotorCmi.cs
@@ -41,7 +41,6 @@ public class MotorCmi
         var resultados = new List<VectorEstado>();
         VectorEstado? anterior = null;
         VectorEstado? actual = null;
-        int? visitaObjetivo = null;
 
         for (int i = 1; i <= visitas; i++)
         {
@@ -76,6 +75,10 @@ public class MotorCmi
             int acumDudoso = (anterior?.AcumDudoso ?? 0) + (respuesta == "Dudoso" ? 1 : 0);
             int ventas = (anterior?.VentasAcum ?? 0) + (compra ? 1 : 0);
 
+            int? indiceMeta = anterior?.IndiceMetaVentas;
+            if (indiceMeta is null && ventas >= _ventasObjetivo)
+                indiceMeta = i;
+
             actual = new VectorEstado
             {
                 Visita = i,
@@ -89,14 +92,12 @@ public class MotorCmi
                 AcumNo = acumNo,
                 AcumDudoso = acumDudoso,
                 ProbAcumSi = (double)acumSi / i,
-                VentasAcum = ventas
+                VentasAcum = ventas,
+                IndiceMetaVentas = indiceMeta
             };
 
             if (i >= desde && i <= hasta)
                 resultados.Add(actual.Clonar());
-
-            if (visitaObjetivo is null && ventas >= _ventasObjetivo)
-                visitaObjetivo = i;
 
             anterior = actual;
         }
@@ -105,7 +106,7 @@ public class MotorCmi
         VectorEstado ultimo = actual!;
         double probSi = (double)ultimo.AcumSi / ultimo.Visita;
         int ventasTotales = ultimo.VentasAcum;
-        return (resultados, ultimo, probSi, ventasTotales, visitaObjetivo);
+        return (resultados, ultimo, probSi, ventasTotales, ultimo.IndiceMetaVentas);
     }
 
     /// <summary>

--- a/SimulacionCmiCore/VectorEstado.cs
+++ b/SimulacionCmiCore/VectorEstado.cs
@@ -31,6 +31,11 @@ public class VectorEstado
     public int VentasAcum { get; set; }
 
     /// <summary>
+    /// Índice de la visita en la que se alcanzó por primera vez la meta de ventas.
+    /// </summary>
+    public int? IndiceMetaVentas { get; init; }
+
+    /// <summary>
     /// Crea una copia superficial del vector.
     /// </summary>
     public VectorEstado Clonar() => (VectorEstado)MemberwiseClone();

--- a/SimulacionCmiWPF/VentanaEnunciado.xaml
+++ b/SimulacionCmiWPF/VentanaEnunciado.xaml
@@ -1,21 +1,16 @@
 <Window x:Class="SimulacionCmiWPF.VentanaEnunciado"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Enunciado" Height="450" Width="800" WindowStartupLocation="CenterOwner">
+        Title="Enunciado" Height="600" Width="800" WindowStartupLocation="CenterOwner">
   <ScrollViewer Margin="8">
     <StackPanel>
       <TextBlock TextWrapping="Wrap">
-        CMI Corporation llevó a cabo una prueba para evaluar la efectividad de un nuevo anuncio por televisión para uno de sus productos domésticos. El anuncio se mostró en un mercado de prueba durante dos semanas. En el estudio de seguimiento se contactó telefónicamente con una selección aleatoria de personas y se les hizo una serie de preguntas sobre la posible compra del producto.
-        <LineBreak/><LineBreak/>
-        Los objetivos del estudio son:
+        CMI Corporation llevó a cabo una prueba, diseñada para evaluar la efectividad de un nuevo anuncio por televisión para uno de sus productos domésticos. El anuncio de televisión se mostró en un mercado de prueba durante un período de dos semanas. En el estudio de seguimiento se contactó telefónicamente con una selección de personas al azar y se les hizo una serie de preguntas sobre la posible compra del producto. El estudio de mercado de prueba proporcionó las siguientes probabilidades.
         <LineBreak/>
-        1. Estimar por simulación la probabilidad general de que un individuo responda "definitivamente sí".
-        <LineBreak/>
-        2. Si el 60 % de los que respondieron "dudoso" terminan comprando, determinar cuántas visitas se necesitan para vender 10000 productos.
       </TextBlock>
-
+      
       <TextBlock Text="Probabilidades a priori" FontWeight="Bold" Margin="0,12,0,4"/>
-      <Border BorderBrush="Black" BorderThickness="1" Margin="0,0,0,8">
+      <Border BorderBrush="Black" BorderThickness="1" Margin="0,0,0,8" MaxWidth="400">
         <Grid>
           <Grid.ColumnDefinitions>
             <ColumnDefinition/>
@@ -46,9 +41,16 @@
           </Border>
         </Grid>
       </Border>
+      
+      <TextBlock TextWrapping="Wrap">
+        <LineBreak/>
+        La respuesta a la pregunta de la posibilidad que comprara el producto dio las siguientes 
+        probabilidades.
+        <LineBreak/>
+      </TextBlock>
 
       <TextBlock Text="Probabilidades condicionales" FontWeight="Bold" Margin="0,12,0,4"/>
-      <Border BorderBrush="Black" BorderThickness="1">
+      <Border BorderBrush="Black" BorderThickness="1" MaxWidth="400">
         <Grid>
           <Grid.ColumnDefinitions>
             <ColumnDefinition/>
@@ -99,6 +101,13 @@
           </Border>
         </Grid>
       </Border>
+      
+      <TextBlock TextWrapping="Wrap">
+        <LineBreak/>
+        Mediante simulación estimar la probabilidad general de que un individuo responda “definitivamente sí” a la pregunta sobre posibilidad de compra.
+        <LineBreak/>
+        Si determinamos que hay una probabilidad de que el 60% de los que respondieron “dudoso”, compren finalmente, ¿determine cuántas visitas se deberán realizar para poder vender 10.000 productos?. 
+      </TextBlock>
     </StackPanel>
   </ScrollViewer>
 </Window>

--- a/SimulacionCmiWPF/VentanaEnunciado.xaml
+++ b/SimulacionCmiWPF/VentanaEnunciado.xaml
@@ -15,50 +15,90 @@
       </TextBlock>
 
       <TextBlock Text="Probabilidades a priori" FontWeight="Bold" Margin="0,12,0,4"/>
-      <Grid Margin="0,0,0,8">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition/>
-          <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-          <RowDefinition/>
-          <RowDefinition/>
-          <RowDefinition/>
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold">Evento</TextBlock>
-        <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold" TextAlignment="Right">Probabilidad</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="0">El individuo recordaba el mensaje</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Right">0,35</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="0">El individuo no podía recordar el mensaje</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Right">0,65</TextBlock>
-      </Grid>
+      <Border BorderBrush="Black" BorderThickness="1" Margin="0,0,0,8">
+        <Grid>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition Width="Auto"/>
+          </Grid.ColumnDefinitions>
+          <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+            <RowDefinition/>
+          </Grid.RowDefinitions>
+          <Border Grid.Row="0" Grid.Column="0" BorderBrush="Black" BorderThickness="0,0,1,1">
+            <TextBlock FontWeight="Bold" Padding="4">Evento</TextBlock>
+          </Border>
+          <Border Grid.Row="0" Grid.Column="1" BorderBrush="Black" BorderThickness="0,0,0,1">
+            <TextBlock FontWeight="Bold" TextAlignment="Right" Padding="4">Probabilidad</TextBlock>
+          </Border>
+          <Border Grid.Row="1" Grid.Column="0" BorderBrush="Black" BorderThickness="0,0,1,1">
+            <TextBlock Padding="4">El individuo recordaba el mensaje</TextBlock>
+          </Border>
+          <Border Grid.Row="1" Grid.Column="1" BorderBrush="Black" BorderThickness="0,0,0,1">
+            <TextBlock TextAlignment="Right" Padding="4">0,35</TextBlock>
+          </Border>
+          <Border Grid.Row="2" Grid.Column="0" BorderBrush="Black" BorderThickness="0,0,1,0">
+            <TextBlock Padding="4">El individuo no podía recordar el mensaje</TextBlock>
+          </Border>
+          <Border Grid.Row="2" Grid.Column="1" BorderBrush="Black" BorderThickness="0,0,0,0">
+            <TextBlock TextAlignment="Right" Padding="4">0,65</TextBlock>
+          </Border>
+        </Grid>
+      </Border>
 
       <TextBlock Text="Probabilidades condicionales" FontWeight="Bold" Margin="0,12,0,4"/>
-      <Grid>
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition/>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-          <RowDefinition/>
-          <RowDefinition/>
-          <RowDefinition/>
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Grid.Column="0" FontWeight="Bold">Evento</TextBlock>
-        <TextBlock Grid.Row="0" Grid.Column="1" FontWeight="Bold" TextAlignment="Right">Def. No</TextBlock>
-        <TextBlock Grid.Row="0" Grid.Column="2" FontWeight="Bold" TextAlignment="Right">Dudoso</TextBlock>
-        <TextBlock Grid.Row="0" Grid.Column="3" FontWeight="Bold" TextAlignment="Right">Def. Sí</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="0">Podía recordar el mensaje</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Right">0,55</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="2" TextAlignment="Right">0,15</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="3" TextAlignment="Right">0,30</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="0">No podía recordar el mensaje</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Right">0,70</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="2" TextAlignment="Right">0,25</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="3" TextAlignment="Right">0,05</TextBlock>
-      </Grid>
+      <Border BorderBrush="Black" BorderThickness="1">
+        <Grid>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
+          </Grid.ColumnDefinitions>
+          <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+            <RowDefinition/>
+          </Grid.RowDefinitions>
+          <Border Grid.Row="0" Grid.Column="0" BorderBrush="Black" BorderThickness="0,0,1,1">
+            <TextBlock FontWeight="Bold" Padding="4">Evento</TextBlock>
+          </Border>
+          <Border Grid.Row="0" Grid.Column="1" BorderBrush="Black" BorderThickness="0,0,1,1">
+            <TextBlock FontWeight="Bold" TextAlignment="Right" Padding="4">Def. No</TextBlock>
+          </Border>
+          <Border Grid.Row="0" Grid.Column="2" BorderBrush="Black" BorderThickness="0,0,1,1">
+            <TextBlock FontWeight="Bold" TextAlignment="Right" Padding="4">Dudoso</TextBlock>
+          </Border>
+          <Border Grid.Row="0" Grid.Column="3" BorderBrush="Black" BorderThickness="0,0,0,1">
+            <TextBlock FontWeight="Bold" TextAlignment="Right" Padding="4">Def. Sí</TextBlock>
+          </Border>
+          <Border Grid.Row="1" Grid.Column="0" BorderBrush="Black" BorderThickness="0,0,1,1">
+            <TextBlock Padding="4">Podía recordar el mensaje</TextBlock>
+          </Border>
+          <Border Grid.Row="1" Grid.Column="1" BorderBrush="Black" BorderThickness="0,0,1,1">
+            <TextBlock TextAlignment="Right" Padding="4">0,55</TextBlock>
+          </Border>
+          <Border Grid.Row="1" Grid.Column="2" BorderBrush="Black" BorderThickness="0,0,1,1">
+            <TextBlock TextAlignment="Right" Padding="4">0,15</TextBlock>
+          </Border>
+          <Border Grid.Row="1" Grid.Column="3" BorderBrush="Black" BorderThickness="0,0,0,1">
+            <TextBlock TextAlignment="Right" Padding="4">0,30</TextBlock>
+          </Border>
+          <Border Grid.Row="2" Grid.Column="0" BorderBrush="Black" BorderThickness="0,0,1,0">
+            <TextBlock Padding="4">No podía recordar el mensaje</TextBlock>
+          </Border>
+          <Border Grid.Row="2" Grid.Column="1" BorderBrush="Black" BorderThickness="0,0,1,0">
+            <TextBlock TextAlignment="Right" Padding="4">0,70</TextBlock>
+          </Border>
+          <Border Grid.Row="2" Grid.Column="2" BorderBrush="Black" BorderThickness="0,0,1,0">
+            <TextBlock TextAlignment="Right" Padding="4">0,25</TextBlock>
+          </Border>
+          <Border Grid.Row="2" Grid.Column="3" BorderBrush="Black" BorderThickness="0,0,0,0">
+            <TextBlock TextAlignment="Right" Padding="4">0,05</TextBlock>
+          </Border>
+        </Grid>
+      </Border>
     </StackPanel>
   </ScrollViewer>
 </Window>

--- a/SimulacionCmiWPF/VentanaResultados.xaml
+++ b/SimulacionCmiWPF/VentanaResultados.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="SimulacionCmiWPF.VentanaResultados"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Resultados" Height="500" Width="1100" WindowStartupLocation="CenterOwner">
+        Title="Resultados" Height="500" Width="1205" WindowStartupLocation="CenterOwner">
   <Grid Margin="10">
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"/>

--- a/SimulacionCmiWPF/VentanaResultados.xaml
+++ b/SimulacionCmiWPF/VentanaResultados.xaml
@@ -36,6 +36,7 @@
             <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
             <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
             <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
+            <DataGridTextColumn Header="Índice meta" Binding="{Binding IndiceMetaVentas}" Width="100" IsReadOnly="True"/>
           </DataGrid.Columns>
         </DataGrid>
       </GroupBox>
@@ -54,6 +55,7 @@
             <DataGridTextColumn Header="Acum Dudoso" Binding="{Binding AcumDudoso}" Width="100"/>
             <DataGridTextColumn Header="P acum Sí" Binding="{Binding ProbAcumSi, StringFormat=F4}" Width="80"/>
             <DataGridTextColumn Header="Ventas" Binding="{Binding VentasAcum}" Width="80"/>
+            <DataGridTextColumn Header="Índice meta" Binding="{Binding IndiceMetaVentas}" Width="100" IsReadOnly="True"/>
           </DataGrid.Columns>
         </DataGrid>
       </GroupBox>


### PR DESCRIPTION
## Resumen
- Se agregó la propiedad `IndiceMetaVentas` al vector de estado y se propagó en la simulación, eliminando variables externas.
- Las tablas de probabilidades del enunciado ahora muestran bordes visibles para una mejor lectura.
- Se añadió la columna explícita "Índice meta" a los grids de resultados.

## Pruebas
- `dotnet test` *(falla: Microsoft.NET.Sdk.WindowsDesktop.targets was not found, falta el SDK de Windows Desktop)*.

------
https://chatgpt.com/codex/tasks/task_e_68900c23b41c8332970a81e8068c108b